### PR TITLE
add user aliases verification on .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -8,3 +8,7 @@ fi
 if [[ -e /usr/share/zsh/biglinux-zsh-prompt ]]; then
   source /usr/share/zsh/biglinux-zsh-prompt
 fi
+# User aliases
+if [[ -e ~/.bash_aliases ]]; then
+  source ~/.bash_aliases
+fi


### PR DESCRIPTION
I added this verification to the .zshrc file so that if the user uses an aliases file for the terminal, they can already use these aliases normally.